### PR TITLE
Add Reconciliation basic structure

### DIFF
--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Reconciliation < ApplicationRecord
+  # Associations
+  belongs_to :store
+  has_many :reconciliation_items, dependent: :destroy
+  has_many :reconciliation_files, dependent: :destroy
+  has_many :matched_items,
+    -> { where(match_status: 'matched') },
+    class_name: 'ReconciliationItem'
+  has_many :unmatched_items,
+    -> { where(match_status: 'unmatched') },
+    class_name: 'ReconciliationItem'
+
+  # Enumerations
+  enum :status, {
+    pending: 'pending',
+    in_progress: 'in_progress',
+    completed: 'completed',
+    failed: 'failed',
+    with_errors: 'with_errors'
+  }
+
+  enum :reconciliation_type, {
+    automatic: 'automatic',
+    manual: 'manual',
+    mixed: 'mixed',
+    csv_import: 'csv_import'
+  }
+
+  enum :initiated_by, {
+    store: 'store',
+    admin: 'admin',
+    system: 'system'
+  }
+
+  # Validations
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  validate :end_date_after_start_date
+
+  # Scopes
+  scope :recent, -> { order(created_at: :desc) }
+  scope :for_period, ->(start_date, end_date) {
+    where('start_date >= ? AND end_date <= ?', start_date, end_date)
+  }
+
+  def date_range
+    start_date..end_date
+  end
+
+  def duration_in_days
+    (end_date - start_date).to_i + 1
+  end
+
+  def can_be_modified?
+    pending? || failed?
+  end
+
+  private
+
+  def end_date_after_start_date
+    return unless start_date && end_date
+
+    errors.add(:end_date, 'must be after or equal to start date') if end_date < start_date
+  end
+end

--- a/app/models/reconciliation_file.rb
+++ b/app/models/reconciliation_file.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ReconciliationFile < ApplicationRecord
+  # Associations
+  belongs_to :reconciliation
+  has_one_attached :file
+
+  # Enumerations
+  enum :status, {
+    pending: 'pending',
+    processing: 'processing',
+    completed: 'completed',
+    failed: 'failed'
+  }
+
+  enum :file_type, {
+    csv: 'csv',
+    excel: 'excel',
+    txt: 'txt'
+  }
+
+  # Validations
+  validates :file_name, presence: true
+  validates :file_type, presence: true
+  validates :status, presence: true
+
+  # Scopes
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/app/models/reconciliation_item.rb
+++ b/app/models/reconciliation_item.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ReconciliationItem < ApplicationRecord
+  # Associations
+  belongs_to :reconciliation
+  belongs_to :source, polymorphic: true
+  belongs_to :target, polymorphic: true
+
+  # Enumerations
+  enum :match_status, {
+    matched: 'matched',
+    unmatched: 'unmatched',
+    partial: 'partial',
+    disputed: 'disputed',
+    pending_review: 'pending_review'
+  }
+
+  # Validations
+  validates :match_status, presence: true
+
+  # Scopes
+  scope :manual_overrides, -> { where(manual_override: true) }
+  scope :automatic_matches, -> { where(manual_override: false) }
+
+  def has_discrepancy?
+    amount_difference != 0 if amount_difference
+  end
+end

--- a/app/models/reconciliation_rule.rb
+++ b/app/models/reconciliation_rule.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ReconciliationRule < ApplicationRecord
+  # Associations
+  has_many :store_reconciliation_rules, dependent: :destroy
+  has_many :stores, through: :store_reconciliation_rules
+
+  # Enums
+  enum :rule_type, {
+    exact: 'exact',
+    date: 'date',
+    percentage: 'percentage',
+    amount: 'amount'
+  }
+
+  # Validations
+  validates :name, presence: true, uniqueness: true
+  validates :rule_type, presence: true, uniqueness: true
+  validates :priority, numericality: {
+    greater_than_or_equal_to: 1,
+    less_than_or_equal_to: 100
+  }
+  validates :default_tolerance_value, numericality: {
+    greater_than_or_equal_to: 0
+  }
+  validate :validate_tolerance_value_by_type
+
+  # Scopes
+  scope :active, -> { where(active: true) }
+  scope :by_priority, -> { order(:priority) }
+
+  private
+
+  def validate_tolerance_value_by_type
+    case rule_type
+    when 'date'
+      errors.add(:default_tolerance_value, 'debe ser entre 0 y 31 días') if default_tolerance_value > 31
+    when 'percentage'
+      errors.add(:default_tolerance_value, 'debe ser entre 0 y 100%') if default_tolerance_value > 100
+    when 'exact'
+      errors.add(:default_tolerance_value, 'debe ser 0 para match exacto') if default_tolerance_value != 0
+    end
+  end
+end

--- a/app/models/store_reconciliation_rule.rb
+++ b/app/models/store_reconciliation_rule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class StoreReconciliationRule < ApplicationRecord
+  # Associations
+  belongs_to :store
+  belongs_to :reconciliation_rule
+
+  # Validations
+  validates :priority, numericality: {
+    greater_than_or_equal_to: 1,
+    less_than_or_equal_to: 100
+  }
+  validates :tolerance_value, numericality: {
+    greater_than_or_equal_to: 0
+  }
+  validates :store_id, uniqueness: {
+    scope: :reconciliation_rule_id,
+    message: 'ya tiene configuración para esta regla'
+  }
+
+  # Scopes
+  scope :active, -> { where(active: true) }
+  scope :by_priority, -> { order(:priority) }
+  scope :customized, -> { where(customized: true) }
+  scope :using_defaults, -> { where(customized: false) }
+end

--- a/db/migrate/20250817013730_create_reconciliations.rb
+++ b/db/migrate/20250817013730_create_reconciliations.rb
@@ -1,0 +1,22 @@
+class CreateReconciliations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reconciliations do |t|
+      t.references :store, null: false, foreign_key: true
+      t.date :start_date, null: false
+      t.date :end_date, null: false
+      t.string :status, null: false, default: 'pending'
+      t.string :reconciliation_type, null: false, default: 'automatic'
+      t.integer :total_matched, null: false, default: 0
+      t.integer :total_unmatched, null: false, default: 0
+      t.decimal :total_amount_matched, precision: 10, scale: 2, default: 0
+      t.decimal :total_amount_unmatched, precision: 10, scale: 2, default: 0
+      t.string :initiated_by, null: false
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    add_index :reconciliations, :status
+    add_index :reconciliations, [:store_id, :start_date, :end_date]
+  end
+end

--- a/db/migrate/20250817014527_create_reconciliation_items.rb
+++ b/db/migrate/20250817014527_create_reconciliation_items.rb
@@ -1,0 +1,27 @@
+class CreateReconciliationItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reconciliation_items do |t|
+      t.references :reconciliation, null: false, foreign_key: true
+
+      t.string :source_type
+      t.bigint :source_id
+
+      t.string :target_type
+      t.bigint :target_id
+
+      t.string :match_status, null: false, default: 'unmatched'
+      t.string :match_rule_applied
+      t.decimal :amount_difference, precision: 10, scale: 2, default: 0
+      t.integer :date_difference_days
+      t.boolean :manual_override, default: false
+      t.text :notes
+
+      t.timestamps
+    end
+
+    add_index :reconciliation_items, [:source_type, :source_id]
+    add_index :reconciliation_items, [:target_type, :target_id]
+    add_index :reconciliation_items, :match_status
+    add_index :reconciliation_items, [:reconciliation_id, :match_status]
+  end
+end

--- a/db/migrate/20250817020000_create_reconciliation_rules.rb
+++ b/db/migrate/20250817020000_create_reconciliation_rules.rb
@@ -1,0 +1,18 @@
+class CreateReconciliationRules < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reconciliation_rules do |t|
+      t.string :rule_type, null: false
+      t.decimal :default_tolerance_value, precision: 10, scale: 2, default: 0
+      t.string :name, null: false
+      t.text :description
+      t.integer :priority, null: false, default: 1
+      t.boolean :active, default: true
+
+      t.timestamps
+    end
+
+    add_index :reconciliation_rules, :rule_type, unique: true
+    add_index :reconciliation_rules, :priority
+    add_index :reconciliation_rules, :active
+  end
+end

--- a/db/migrate/20250817020001_create_store_reconciliation_rules.rb
+++ b/db/migrate/20250817020001_create_store_reconciliation_rules.rb
@@ -1,0 +1,22 @@
+class CreateStoreReconciliationRules < ActiveRecord::Migration[8.0]
+  def change
+    create_table :store_reconciliation_rules do |t|
+      t.references :store, null: false, foreign_key: true
+      t.references :reconciliation_rule, null: false, foreign_key: true
+
+      t.decimal :tolerance_value, precision: 10, scale: 2, null: false
+      t.integer :priority, null: false
+      t.boolean :active, default: true
+
+      t.timestamps
+    end
+
+    add_index :store_reconciliation_rules,
+      [:store_id, :reconciliation_rule_id],
+      unique: true,
+      name: 'idx_store_recon_rules_unique'
+    add_index :store_reconciliation_rules,
+      [:store_id, :active, :priority],
+      name: 'idx_store_recon_rules_lookup'
+  end
+end

--- a/db/migrate/20250817184427_create_reconciliation_files.rb
+++ b/db/migrate/20250817184427_create_reconciliation_files.rb
@@ -1,0 +1,14 @@
+class CreateReconciliationFiles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reconciliation_files do |t|
+      t.references :reconciliation, foreign_key: true, null: false
+
+      t.string :file_name, null: false
+      t.string :file_type, null: false
+      t.string :status, null: false, default: 'pending'
+
+      t.timestamps
+    end
+    add_index :reconciliation_files, :status
+  end
+end

--- a/db/migrate/20250817190244_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250817190244_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_17_013320) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_17_190244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "customers", force: :cascade do |t|
     t.string "name"
@@ -24,6 +52,74 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_17_013320) do
     t.datetime "updated_at", null: false
     t.index ["document_number"], name: "index_customers_on_document_number", unique: true
     t.index ["email"], name: "index_customers_on_email", unique: true
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "reconciliation_files", force: :cascade do |t|
+    t.bigint "reconciliation_id", null: false
+    t.string "file_name", null: false
+    t.string "file_type", null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reconciliation_id"], name: "index_reconciliation_files_on_reconciliation_id"
+    t.index ["status"], name: "index_reconciliation_files_on_status"
+  end
+
+  create_table "reconciliation_items", force: :cascade do |t|
+    t.bigint "reconciliation_id", null: false
+    t.string "source_type"
+    t.bigint "source_id"
+    t.string "target_type"
+    t.bigint "target_id"
+    t.string "match_status", default: "unmatched", null: false
+    t.string "match_rule_applied"
+    t.decimal "amount_difference", precision: 10, scale: 2, default: "0.0"
+    t.integer "date_difference_days"
+    t.boolean "manual_override", default: false
+    t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["match_status"], name: "index_reconciliation_items_on_match_status"
+    t.index ["reconciliation_id", "match_status"], name: "idx_on_reconciliation_id_match_status_84941c32a3"
+    t.index ["reconciliation_id"], name: "index_reconciliation_items_on_reconciliation_id"
+    t.index ["source_type", "source_id"], name: "index_reconciliation_items_on_source_type_and_source_id"
+    t.index ["target_type", "target_id"], name: "index_reconciliation_items_on_target_type_and_target_id"
+  end
+
+  create_table "reconciliation_rules", force: :cascade do |t|
+    t.string "rule_type", null: false
+    t.decimal "default_tolerance_value", precision: 10, scale: 2, default: "0.0"
+    t.string "name", null: false
+    t.text "description"
+    t.integer "priority", default: 1, null: false
+    t.boolean "active", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_reconciliation_rules_on_active"
+    t.index ["priority"], name: "index_reconciliation_rules_on_priority"
+    t.index ["rule_type"], name: "index_reconciliation_rules_on_rule_type", unique: true
+  end
+
+  create_table "reconciliations", force: :cascade do |t|
+    t.bigint "store_id", null: false
+    t.date "start_date", null: false
+    t.date "end_date", null: false
+    t.string "status", default: "pending", null: false
+    t.string "reconciliation_type", default: "automatic", null: false
+    t.integer "total_matched", default: 0, null: false
+    t.integer "total_unmatched", default: 0, null: false
+    t.decimal "total_amount_matched", precision: 10, scale: 2, default: "0.0"
+    t.decimal "total_amount_unmatched", precision: 10, scale: 2, default: "0.0"
+    t.string "initiated_by", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_reconciliations_on_status"
+    t.index ["store_id", "start_date", "end_date"], name: "index_reconciliations_on_store_id_and_start_date_and_end_date"
+    t.index ["store_id"], name: "index_reconciliations_on_store_id"
   end
 
   create_table "sales", force: :cascade do |t|
@@ -42,6 +138,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_17_013320) do
     t.index ["sale_number"], name: "index_sales_on_sale_number", unique: true
     t.index ["status"], name: "index_sales_on_status"
     t.index ["store_id"], name: "index_sales_on_store_id"
+  end
+
+  create_table "store_reconciliation_rules", force: :cascade do |t|
+    t.bigint "store_id", null: false
+    t.bigint "reconciliation_rule_id", null: false
+    t.decimal "tolerance_value", precision: 10, scale: 2, null: false
+    t.integer "priority", null: false
+    t.boolean "active", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reconciliation_rule_id"], name: "index_store_reconciliation_rules_on_reconciliation_rule_id"
+    t.index ["store_id", "active", "priority"], name: "idx_store_recon_rules_lookup"
+    t.index ["store_id", "reconciliation_rule_id"], name: "idx_store_recon_rules_unique", unique: true
+    t.index ["store_id"], name: "index_store_reconciliation_rules_on_store_id"
   end
 
   create_table "stores", force: :cascade do |t|
@@ -94,8 +204,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_17_013320) do
     t.index ["owner_type", "owner_id"], name: "index_wallets_on_owner"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "reconciliation_files", "reconciliations"
+  add_foreign_key "reconciliation_items", "reconciliations"
+  add_foreign_key "reconciliations", "stores"
   add_foreign_key "sales", "customers"
   add_foreign_key "sales", "stores"
+  add_foreign_key "store_reconciliation_rules", "reconciliation_rules"
+  add_foreign_key "store_reconciliation_rules", "stores"
   add_foreign_key "transactions", "customers"
   add_foreign_key "transactions", "stores"
   add_foreign_key "transactions", "wallets"


### PR DESCRIPTION
### Changelog

This PR includes the complete reconciliation workflow, including:

- 5 new DB migrations and their respective models for:
    - `reconciliations`
    - `reconciliation_items`
    - `reconciliation_rules`
    - `store_reconciliation_rules`
    - `reconciliation_files`
- 1 extra DB migration for active storage

### Migration plan
- To run `DB structure migrations` you can execute `rails db:migrate`

### Rollback plan
- To rollback `DB structure migrations` you can execute `rails db:rollback VERSION=20250817013320` or `rails db:migrate:down VERSION=20250817013320`
