### PR TITLE
Fix unique priority per store

### DIFF
--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -25,11 +25,11 @@ class Reconciliation < ApplicationRecord
     automatic: 'automatic',
     manual: 'manual',
     mixed: 'mixed',
-    csv_import: 'csv_import'
+    file_import: 'file_import'
   }
 
   enum :initiated_by, {
-    store: 'store',
+    store_user: 'store_user',
     admin: 'admin',
     system: 'system'
   }

--- a/app/models/store_reconciliation_rule.rb
+++ b/app/models/store_reconciliation_rule.rb
@@ -10,6 +10,10 @@ class StoreReconciliationRule < ApplicationRecord
     greater_than_or_equal_to: 1,
     less_than_or_equal_to: 100
   }
+  validates :priority, uniqueness: {
+    scope: :store_id,
+    message: 'ya existe otra regla con esta prioridad para la tienda'
+  }
   validates :tolerance_value, numericality: {
     greater_than_or_equal_to: 0
   }
@@ -17,8 +21,22 @@ class StoreReconciliationRule < ApplicationRecord
     scope: :reconciliation_rule_id,
     message: 'ya tiene configuración para esta regla'
   }
+  validate :validate_tolerance_value_by_type
 
   # Scopes
   scope :active, -> { where(active: true) }
   scope :by_priority, -> { order(:priority) }
+
+  private
+
+  def validate_tolerance_value_by_type
+    case reconciliation_rule.rule_type
+    when 'date'
+      errors.add(:tolerance_value, 'debe ser entre 0 y 31 días') if tolerance_value > 31
+    when 'percentage'
+      errors.add(:tolerance_value, 'debe ser entre 0 y 100%') if tolerance_value > 100
+    when 'exact'
+      errors.add(:tolerance_value, 'debe ser 0 para match exacto') if tolerance_value != 0
+    end
+  end
 end

--- a/db/migrate/20250819063325_add_unique_priority_index_to_store_reconciliation_rules.rb
+++ b/db/migrate/20250819063325_add_unique_priority_index_to_store_reconciliation_rules.rb
@@ -1,0 +1,8 @@
+class AddUniquePriorityIndexToStoreReconciliationRules < ActiveRecord::Migration[8.0]
+  def change
+    add_index :store_reconciliation_rules, 
+              [:store_id, :priority], 
+              unique: true,
+              name: 'idx_store_priority_unique'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_17_190244) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_19_063325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -147,6 +147,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_17_190244) do
     t.datetime "updated_at", null: false
     t.index ["reconciliation_rule_id"], name: "index_store_reconciliation_rules_on_reconciliation_rule_id"
     t.index ["store_id", "active", "priority"], name: "idx_store_recon_rules_lookup"
+    t.index ["store_id", "priority"], name: "idx_store_priority_unique", unique: true
     t.index ["store_id", "reconciliation_rule_id"], name: "idx_store_recon_rules_unique", unique: true
     t.index ["store_id"], name: "index_store_reconciliation_rules_on_store_id"
   end


### PR DESCRIPTION
### Changelog

This PR includes a bugfix to avoid saving duplicated priority rules per store

### Migration plan
- To run DB migration, you can run `rails db:migrate`

### Rollback plan
- To rollback DB migration, you can run `rails db:rollback STEP=1` or `rails db:mirate:down STEP=1`